### PR TITLE
Ensure patch is working from correct directory

### DIFF
--- a/buildme.sh
+++ b/buildme.sh
@@ -107,6 +107,7 @@ echo "Downloading Marvell DDR"
 if [[ ! -d $ROOTDIR/build/bootloader/mv-ddr-marvell ]]; then
 	cd $ROOTDIR/build/bootloader
 	git clone --branch=$MVDDR_BRANCH https://github.com/MarvellEmbeddedProcessors/mv-ddr-marvell.git
+	cd mv-ddr-marvell
 else
 	cd $ROOTDIR/build/bootloader/mv-ddr-marvell
 	git reset


### PR DESCRIPTION
When cloning mv-ddr-marvell, it will not end up in the same working
directory as when it is already checked out, resulting in patch
failing to find the correct files to patch.